### PR TITLE
Update system.drawing.text.prg

### DIFF
--- a/source/system.drawing.text.prg
+++ b/source/system.drawing.text.prg
@@ -453,7 +453,7 @@ DEFINE CLASS xfcPrivateFontCollection AS xfcFontCollection
 		LOCAL loExc AS Exception
 		TRY
 		
-			This.SetStatus(xfcGdipPrivateAddFontFile(This.Handle, STRCONV(m.tcFilename,5)))
+			This.SetStatus(xfcGdipPrivateAddFontFile(This.Handle, STRCONV(m.tcFilename+0h00,5)))
 		
 		CATCH TO loExc
 			THROW_EXCEPTION


### PR DESCRIPTION
xfcPrivateFontCollection.AddFontFile doesn't add 0h00 to m.tcFilename when converts it to UNICODE with STRCONV(m.tcFilename,5). Thus the function may exit with error status 10 (FileNotFound)